### PR TITLE
feat: add performance analytics, rolling factor chart, and comprehens…

### DIFF
--- a/main.py
+++ b/main.py
@@ -136,9 +136,23 @@ def main():
     print(f"    {'Cash':<14}  {'':>17}   €{portfolio.cash:>10,.2f}")
     print(f"{'='*52}")
 
+    from reporting.performance_metrics import compute_all_metrics, write_summary_report
+    metrics = compute_all_metrics(
+        history=backtest.history,
+        trades=executor.trades,
+        spy_prices=spy_prices,
+        initial_value=initial_value,
+    )
+    write_summary_report(metrics, output_path="reports/summary.txt")
+
     from reporting.charts import plot_results
-    plot_results(history=backtest.history, trades=executor.trades,
-                 spy_prices=spy_prices, initial_value=initial_value)
+    plot_results(
+        history=backtest.history,
+        trades=executor.trades,
+        spy_prices=spy_prices,
+        initial_value=initial_value,
+        exposure_history=strategy.exposure_history,
+    )
 
 
 if __name__ == "__main__":

--- a/reporting/performance_metrics.py
+++ b/reporting/performance_metrics.py
@@ -1,0 +1,217 @@
+"""
+Performance analytics for portfolio backtests.
+
+Metrics:
+  - Sharpe ratio, Sortino ratio
+  - Max drawdown, drawdown duration
+  - Alpha, beta, information ratio, annualized tracking error vs benchmark
+  - Average monthly turnover
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+
+
+def sharpe_ratio(portfolio_returns: pd.Series, risk_free: float = 0.0) -> float:
+    """Annualized Sharpe ratio. risk_free is annualized (default 0%)."""
+    if len(portfolio_returns) < 2:
+        return float("nan")
+    ann_return = portfolio_returns.mean() * 252
+    ann_vol = portfolio_returns.std() * np.sqrt(252)
+    if ann_vol == 0:
+        return float("nan")
+    return (ann_return - risk_free) / ann_vol
+
+
+def sortino_ratio(portfolio_returns: pd.Series, risk_free: float = 0.0) -> float:
+    """Annualized Sortino ratio using downside deviation below zero."""
+    if len(portfolio_returns) < 2:
+        return float("nan")
+    ann_return = portfolio_returns.mean() * 252
+    downside = portfolio_returns[portfolio_returns < 0]
+    if len(downside) == 0:
+        return float("inf")
+    downside_vol = downside.std() * np.sqrt(252)
+    if downside_vol == 0:
+        return float("nan")
+    return (ann_return - risk_free) / downside_vol
+
+
+def max_drawdown(values: pd.Series) -> float:
+    """Maximum peak-to-trough drawdown as a positive fraction (e.g. 0.25 = 25%)."""
+    if len(values) < 2:
+        return 0.0
+    peak = values.cummax()
+    drawdown = (values - peak) / peak
+    return float(-drawdown.min())
+
+
+def drawdown_duration(values: pd.Series) -> int:
+    """Calendar days spent in the longest continuous drawdown period."""
+    if len(values) < 2:
+        return 0
+    peak = values.cummax()
+    in_drawdown = values < peak
+    max_duration = 0
+    current_start = None
+    for date, flag in in_drawdown.items():
+        if flag and current_start is None:
+            current_start = date
+        elif not flag and current_start is not None:
+            duration = (date - current_start).days
+            max_duration = max(max_duration, duration)
+            current_start = None
+    if current_start is not None:
+        duration = (values.index[-1] - current_start).days
+        max_duration = max(max_duration, duration)
+    return max_duration
+
+
+def alpha_beta(portfolio_returns: pd.Series, benchmark_returns: pd.Series):
+    """
+    OLS regression of portfolio daily returns on benchmark daily returns.
+    Returns (annualized_alpha, beta).
+    """
+    common = portfolio_returns.index.intersection(benchmark_returns.index)
+    if len(common) < 10:
+        return float("nan"), float("nan")
+    p = portfolio_returns.loc[common].values
+    b = benchmark_returns.loc[common].values
+    cov = np.cov(p, b, ddof=1)
+    if cov[1, 1] == 0:
+        return float("nan"), float("nan")
+    beta = cov[0, 1] / cov[1, 1]
+    daily_alpha = p.mean() - beta * b.mean()
+    return daily_alpha * 252, beta
+
+
+def information_ratio(portfolio_returns: pd.Series, benchmark_returns: pd.Series) -> float:
+    """Annualized information ratio: active_return / tracking_error."""
+    common = portfolio_returns.index.intersection(benchmark_returns.index)
+    if len(common) < 2:
+        return float("nan")
+    active = portfolio_returns.loc[common] - benchmark_returns.loc[common]
+    te = active.std() * np.sqrt(252)
+    if te == 0:
+        return float("nan")
+    return active.mean() * 252 / te
+
+
+def annualized_tracking_error(portfolio_returns: pd.Series, benchmark_returns: pd.Series) -> float:
+    """Annualized tracking error: std(active_returns) * sqrt(252)."""
+    common = portfolio_returns.index.intersection(benchmark_returns.index)
+    if len(common) < 2:
+        return float("nan")
+    active = portfolio_returns.loc[common] - benchmark_returns.loc[common]
+    return float(active.std() * np.sqrt(252))
+
+
+def average_monthly_turnover(trades: list, history: list) -> float:
+    """Average monthly turnover as a fraction of portfolio value."""
+    if not trades or not history:
+        return 0.0
+    trades_df = pd.DataFrame(trades)
+    if "amount" not in trades_df.columns or "date" not in trades_df.columns:
+        return 0.0
+    trades_df["date"] = pd.to_datetime(trades_df["date"])
+    trades_df["month"] = trades_df["date"].dt.to_period("M")
+    monthly_traded = trades_df.groupby("month")["amount"].sum()
+
+    history_df = pd.DataFrame(
+        [{"date": h["date"], "value": h["value"]} for h in history]
+    )
+    history_df["month"] = pd.to_datetime(history_df["date"]).dt.to_period("M")
+    monthly_values = history_df.groupby("month")["value"].last()
+
+    common = monthly_traded.index.intersection(monthly_values.index)
+    if len(common) == 0:
+        return 0.0
+    turnovers = monthly_traded.loc[common] / monthly_values.loc[common]
+    return float(turnovers.mean())
+
+
+def compute_all_metrics(
+    history: list,
+    trades: list,
+    spy_prices: pd.Series,
+    initial_value: float,
+) -> dict:
+    """Compute all performance metrics and return as a dict."""
+    history_df = pd.DataFrame(
+        [{"date": h["date"], "value": h["value"]} for h in history]
+    ).set_index("date")
+    values = history_df["value"].dropna()
+    if len(values) < 2:
+        return {}
+
+    portfolio_returns = values.pct_change().dropna()
+    spy = spy_prices.dropna().reindex(values.index, method="ffill").dropna()
+    spy_returns = spy.pct_change().dropna()
+
+    sharpe = sharpe_ratio(portfolio_returns)
+    sortino = sortino_ratio(portfolio_returns)
+    mdd = max_drawdown(values)
+    dd_dur = drawdown_duration(values)
+    ann_alpha, beta = alpha_beta(portfolio_returns, spy_returns)
+    ir = information_ratio(portfolio_returns, spy_returns)
+    te = annualized_tracking_error(portfolio_returns, spy_returns)
+    turnover = average_monthly_turnover(trades, history)
+
+    years = (values.index[-1] - values.index[0]).days / 365.25
+    ann_return = (
+        ((values.iloc[-1] / values.iloc[0]) ** (1 / years) - 1) * 100
+        if years > 0 else 0.0
+    )
+
+    return {
+        "annualized_return_pct": ann_return,
+        "sharpe_ratio": sharpe,
+        "sortino_ratio": sortino,
+        "max_drawdown_pct": mdd * 100,
+        "max_drawdown_duration_days": dd_dur,
+        "alpha_annualized": ann_alpha,
+        "beta": beta,
+        "information_ratio": ir,
+        "annualized_tracking_error_pct": te * 100,
+        "avg_monthly_turnover_pct": turnover * 100,
+    }
+
+
+def _fmt(v, sign=False, decimals=2, suffix=""):
+    """Format a numeric metric, returning 'N/A' for nan/inf."""
+    if not isinstance(v, (int, float)):
+        return "N/A"
+    if v != v or abs(v) == float("inf"):  # nan or inf
+        return "N/A"
+    fmt = f"{'+'if sign else ''}.{decimals}f"
+    return f"{v:{fmt}}{suffix}"
+
+
+def write_summary_report(metrics: dict, output_path: str = "reports/summary.txt") -> None:
+    """Write a text summary of all performance metrics to output_path."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    lines = [
+        "=" * 52,
+        "  PERFORMANCE SUMMARY",
+        "=" * 52,
+        f"  Annualized return:     {_fmt(metrics.get('annualized_return_pct', float('nan')), sign=True, suffix='%')}",
+        f"  Sharpe ratio:          {_fmt(metrics.get('sharpe_ratio', float('nan')), sign=True)}",
+        f"  Sortino ratio:         {_fmt(metrics.get('sortino_ratio', float('nan')), sign=True)}",
+        f"  Max drawdown:          {_fmt(metrics.get('max_drawdown_pct', float('nan')), suffix='%')}",
+        f"  Drawdown duration:     {metrics.get('max_drawdown_duration_days', 0)} days",
+        "",
+        "  --- Benchmark-relative (vs SPY) ---",
+        f"  Alpha (annualized):    {_fmt(metrics.get('alpha_annualized', float('nan')), sign=True, decimals=4)}",
+        f"  Beta:                  {_fmt(metrics.get('beta', float('nan')), sign=True, decimals=3)}",
+        f"  Information ratio:     {_fmt(metrics.get('information_ratio', float('nan')), sign=True)}",
+        f"  Tracking error (ann.): {_fmt(metrics.get('annualized_tracking_error_pct', float('nan')), suffix='%')}",
+        "",
+        "  --- Turnover ---",
+        f"  Avg monthly turnover:  {_fmt(metrics.get('avg_monthly_turnover_pct', float('nan')), suffix='%')}",
+        "=" * 52,
+    ]
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    print(f"\nPerformance summary written to {output_path}")

--- a/strategy/strategy.py
+++ b/strategy/strategy.py
@@ -38,6 +38,7 @@ class FactorReplicationStrategy:
         self.last_rebalance_date = None
         self.realized_gains = []
         self.total_interest_paid = 0.0
+        self.exposure_history = []  # list of {date, exposure, factors} snapshots
 
     def on_date(self, date):
         # Margin: daily interest accrual and margin-call check (every day)
@@ -86,6 +87,12 @@ class FactorReplicationStrategy:
         universe = self.universe_selector.select(exposures, r2, volatility=volatility)
         exposures = exposures.loc[universe]
         current_exposure = self._portfolio_factor_exposure(exposures, date)
+        # Snapshot portfolio factor exposure on every rebalance date
+        self.exposure_history.append({
+            "date": date,
+            "exposure": current_exposure.tolist(),
+            "factors": list(exposures.columns),
+        })
         target_exposure = np.array(
             self.target.vector(exposures.columns)
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,125 @@
+"""
+Shared pytest fixtures providing synthetic market data for unit and integration tests.
+No network calls are made — all data is generated deterministically from fixed seeds.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from data.market_data import MarketData
+
+# ---------------------------------------------------------------------------
+# Tickers and factor configuration
+# ---------------------------------------------------------------------------
+
+TICKERS = ["AAPL", "MSFT", "GOOG", "AMZN", "META"]
+FACTORS = ["MKT", "Value", "Momentum"]
+
+# Factor betas per ticker: [MKT, Value, Momentum]
+# Designed so each stock has high R² in factor regressions (≥ 0.3 threshold).
+_BETAS = {
+    "AAPL": [1.2,  0.3,  0.5],
+    "MSFT": [0.9,  0.2,  0.4],
+    "GOOG": [1.1, -0.1,  0.3],
+    "AMZN": [0.8,  0.6, -0.2],
+    "META": [1.0,  0.4,  0.1],
+}
+
+# AMZN and META carry a negative daily drift so they accumulate unrealized losses
+# by the end of 2022, enabling tax-loss harvesting tests.
+_DRIFTS = {
+    "AAPL": 0.0,
+    "MSFT": 0.0,
+    "GOOG": 0.0,
+    "AMZN": -0.001,
+    "META": -0.0008,
+}
+
+# ---------------------------------------------------------------------------
+# Date ranges
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def warmup_dates():
+    """
+    Full date range including ~18 months of warmup before the backtest start.
+    Required so the 252-calendar-day lookback window is fully populated on day 1.
+    """
+    return pd.bdate_range("2020-06-01", "2023-12-29")
+
+
+@pytest.fixture(scope="session")
+def trading_dates():
+    """Backtest date range: ~2 years of business days (2022-01-03 to 2023-12-29)."""
+    return pd.bdate_range("2022-01-03", "2023-12-29")
+
+
+# ---------------------------------------------------------------------------
+# Market data fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def small_factor_returns(warmup_dates):
+    """
+    Deterministic Fama-French-style 3-factor returns over the full warmup+backtest
+    period. No network calls.
+    """
+    np.random.seed(0)
+    n = len(warmup_dates)
+    return pd.DataFrame(
+        {
+            "MKT":      np.random.normal(0.0003, 0.010, n),
+            "Value":    np.random.normal(0.0001, 0.007, n),
+            "Momentum": np.random.normal(0.0002, 0.008, n),
+        },
+        index=warmup_dates,
+    )
+
+
+@pytest.fixture(scope="session")
+def small_prices(warmup_dates, small_factor_returns):
+    """
+    5-ticker price DataFrame covering the full warmup+backtest period.
+    Returns are constructed as a linear combination of factor returns plus low
+    idiosyncratic noise, so each stock achieves R² ≥ 0.7 in the factor regression.
+    AMZN and META carry a deliberate negative drift so they develop unrealized
+    losses by the end of 2022.
+    """
+    np.random.seed(42)
+    n = len(warmup_dates)
+    factor_arr = small_factor_returns.values  # shape (n, 3)
+    prices = {}
+    for ticker, betas in _BETAS.items():
+        idio = np.random.normal(0, 0.004, n)   # small idiosyncratic noise → high R²
+        ret = factor_arr @ np.array(betas) + _DRIFTS[ticker] + idio
+        prices[ticker] = 100.0 * np.cumprod(1 + ret)
+    return pd.DataFrame(prices, index=warmup_dates)
+
+
+@pytest.fixture(scope="session")
+def small_spy_prices(warmup_dates, small_factor_returns):
+    """Deterministic SPY price series derived from the MKT factor."""
+    spy_returns = small_factor_returns["MKT"].values
+    spy = 400.0 * np.cumprod(1 + spy_returns)
+    return pd.Series(spy, index=warmup_dates, name="SPY")
+
+
+@pytest.fixture(scope="session")
+def small_market_data(small_prices, trading_dates):
+    """
+    MarketData built directly from synthetic prices (no yfinance).
+
+    - ``prices``: trimmed to the backtest start date (2022-01-03) so the engine
+      iterates only over the intended window.
+    - ``returns``: computed from the full price history (including warmup) so the
+      252-day lookback in the strategy is always populated.
+    """
+    returns_full = small_prices.pct_change().dropna(how="all")
+    prices = small_prices.loc[small_prices.index >= trading_dates[0]]
+    return MarketData(prices=prices, returns=returns_full)

--- a/tests/test_backtest_integration.py
+++ b/tests/test_backtest_integration.py
@@ -1,0 +1,205 @@
+"""
+Integration test: runs the full pipeline end-to-end on 2 years of synthetic
+price/factor data.  No yfinance calls are made — all data comes from the
+conftest fixtures.
+
+Assertions:
+  - Portfolio value is positive throughout
+  - Realized gains list is maintained
+  - Trades are recorded
+  - Any harvest events that fire are in November or December
+  - Exposure history is captured at each rebalance
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from backtest.engine import BacktestEngine
+from config import MarginConfig, TaxConfig, TradingCostConfig
+from decisions.decision_engine import DecisionEngine
+from execution.executor import Executor
+from factors.factor_model import FactorModel
+from portfolio.portfolio import Portfolio
+from strategy.strategy import FactorReplicationStrategy
+from targets.factor_target import FactorTarget
+from tax.tax_engine import TaxEngine
+from tax.tax_harvesting import TaxHarvestingEngine
+from trading.margin_cost import MarginCostModel
+from universe.universe_selector import UniverseSelector
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped backtest fixture (runs once for all tests in this file)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def backtest_result(small_market_data, small_factor_returns, small_spy_prices):
+    """
+    Run the full pipeline once and return (backtest_engine, strategy, executor).
+    Uses min_r2=0.1 (relaxed) so all synthetic tickers pass the universe filter.
+    """
+    tax_config = TaxConfig()
+    tax_engine = TaxEngine(config=tax_config)
+    margin_config = MarginConfig(enabled=False)
+    margin_cost_model = MarginCostModel()
+    trading_cost_config = TradingCostConfig()
+    decision_engine = DecisionEngine(
+        tax_engine=tax_engine,
+        trading_cost_config=trading_cost_config,
+        margin_config=margin_config,
+        margin_cost_model=margin_cost_model,
+    )
+    portfolio = Portfolio(cash=20_000.0)
+    executor = Executor(small_market_data)
+    harvester = TaxHarvestingEngine(
+        config=tax_config,
+        tax_engine=tax_engine,
+        executor=executor,
+    )
+    factor_model = FactorModel(small_factor_returns)
+    universe_selector = UniverseSelector(min_r2=0.1)
+    target = FactorTarget({"Value": 0.6, "Momentum": 0.4})
+
+    strategy = FactorReplicationStrategy(
+        market_data=small_market_data,
+        factor_model=factor_model,
+        universe_selector=universe_selector,
+        target=target,
+        portfolio=portfolio,
+        decision_engine=decision_engine,
+        executor=executor,
+        harvester=harvester,
+        margin_config=margin_config,
+        margin_cost_model=margin_cost_model,
+    )
+    backtest = BacktestEngine(portfolio=portfolio, strategy=strategy)
+    backtest.run(small_market_data.prices.index)
+    return backtest, strategy, executor
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integrity
+# ---------------------------------------------------------------------------
+
+class TestPipelineRuns:
+    def test_history_is_populated(self, backtest_result):
+        backtest, _, _ = backtest_result
+        assert len(backtest.history) > 0
+
+    def test_history_length_matches_price_dates(self, backtest_result, small_market_data):
+        backtest, _, _ = backtest_result
+        assert len(backtest.history) == len(small_market_data.prices.index)
+
+    def test_portfolio_value_positive(self, backtest_result):
+        backtest, _, _ = backtest_result
+        final_value = backtest.history[-1]["value"]
+        assert final_value > 0, f"Final portfolio value should be positive, got {final_value}"
+
+    def test_all_daily_values_positive(self, backtest_result):
+        backtest, _, _ = backtest_result
+        for entry in backtest.history:
+            assert entry["value"] > 0, f"Negative portfolio value on {entry['date']}: {entry['value']}"
+
+    def test_history_entry_schema(self, backtest_result):
+        backtest, _, _ = backtest_result
+        for entry in backtest.history:
+            assert "date" in entry
+            assert "value" in entry
+            assert "leverage" in entry
+            assert "allocations" in entry
+            assert "cash" in entry["allocations"]
+
+    def test_leverage_without_margin_is_one(self, backtest_result):
+        backtest, _, _ = backtest_result
+        for entry in backtest.history:
+            assert abs(entry["leverage"] - 1.0) < 1e-6, (
+                f"Leverage should be 1.0 without margin, got {entry['leverage']} on {entry['date']}"
+            )
+
+    def test_positions_non_negative_shares(self, backtest_result):
+        backtest, _, _ = backtest_result
+        for ticker, position in backtest.portfolio.positions.items():
+            assert position.total_shares() >= 0, f"{ticker} has negative shares"
+
+
+# ---------------------------------------------------------------------------
+# Realized gains tracking
+# ---------------------------------------------------------------------------
+
+class TestRealizedGains:
+    def test_realized_gains_is_list(self, backtest_result):
+        _, strategy, _ = backtest_result
+        assert isinstance(strategy.realized_gains, list)
+
+    def test_realized_gain_record_schema(self, backtest_result):
+        _, strategy, _ = backtest_result
+        for record in strategy.realized_gains:
+            assert "date" in record
+            assert "ticker" in record
+            assert "realized_gain" in record
+
+    def test_trades_were_executed(self, backtest_result):
+        _, _, executor = backtest_result
+        assert len(executor.trades) > 0, "At least some trades should have been executed"
+
+    def test_buy_trades_have_positive_amounts(self, backtest_result):
+        _, _, executor = backtest_result
+        buys = [t for t in executor.trades if t["type"] == "buy"]
+        assert len(buys) > 0, "At least one buy trade should exist"
+        for t in buys:
+            assert t["amount"] > 0, f"Buy amount must be positive, got {t['amount']}"
+
+
+# ---------------------------------------------------------------------------
+# Tax-loss harvest events
+# ---------------------------------------------------------------------------
+
+class TestHarvestEvents:
+    def test_harvest_events_only_in_nov_dec(self, backtest_result):
+        """Any harvest events that fired must fall in November or December."""
+        _, strategy, _ = backtest_result
+        harvest_events = [r for r in strategy.realized_gains if r.get("is_harvest")]
+        for event in harvest_events:
+            assert event["date"].month in {11, 12}, (
+                f"Harvest event on {event['date']} is not in Nov/Dec"
+            )
+
+    def test_harvest_events_have_non_negative_tax_saved(self, backtest_result):
+        _, strategy, _ = backtest_result
+        harvest_events = [r for r in strategy.realized_gains if r.get("is_harvest")]
+        for event in harvest_events:
+            assert event.get("tax_saved", 0) >= 0, (
+                f"tax_saved must be non-negative, got {event.get('tax_saved')}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Factor exposure history
+# ---------------------------------------------------------------------------
+
+class TestExposureHistory:
+    def test_exposure_history_populated(self, backtest_result):
+        _, strategy, _ = backtest_result
+        assert len(strategy.exposure_history) > 0, (
+            "strategy.exposure_history should be populated at each rebalance date"
+        )
+
+    def test_exposure_history_schema(self, backtest_result):
+        _, strategy, _ = backtest_result
+        for snap in strategy.exposure_history:
+            assert "date" in snap
+            assert "exposure" in snap
+            assert "factors" in snap
+            assert len(snap["exposure"]) == len(snap["factors"])
+
+    def test_exposure_entries_match_factor_names(self, backtest_result):
+        _, strategy, _ = backtest_result
+        for snap in strategy.exposure_history:
+            for name in snap["factors"]:
+                assert isinstance(name, str)
+            for val in snap["exposure"]:
+                assert isinstance(val, float)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,167 @@
+"""
+Unit tests for BacktestEngine.
+
+Uses a no-op strategy stub so tests are isolated from strategy logic.
+Fixtures come from conftest.py.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from backtest.engine import BacktestEngine
+from portfolio.portfolio import Portfolio
+
+
+# ---------------------------------------------------------------------------
+# Minimal strategy stub
+# ---------------------------------------------------------------------------
+
+class _NoopStrategy:
+    """Strategy that does nothing — lets the engine record history untouched."""
+
+    def __init__(self, market_data):
+        self.market_data = market_data
+
+    def on_date(self, date):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# History recording
+# ---------------------------------------------------------------------------
+
+class TestHistoryRecording:
+    def test_history_length_matches_date_count(self, small_market_data):
+        portfolio = Portfolio(cash=10_000.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        engine.run(small_market_data.prices.index)
+        assert len(engine.history) == len(small_market_data.prices.index)
+
+    def test_history_entry_has_required_keys(self, small_market_data):
+        portfolio = Portfolio(cash=5_000.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        engine.run(small_market_data.prices.index[:3])
+        for entry in engine.history:
+            assert "date" in entry
+            assert "value" in entry
+            assert "leverage" in entry
+            assert "allocations" in entry
+
+    def test_allocations_always_contains_cash(self, small_market_data):
+        portfolio = Portfolio(cash=7_500.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        engine.run(small_market_data.prices.index[:5])
+        for entry in engine.history:
+            assert "cash" in entry["allocations"]
+
+    def test_dates_in_history_match_input(self, small_market_data):
+        portfolio = Portfolio(cash=1_000.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        dates = small_market_data.prices.index[:10]
+        engine.run(dates)
+        recorded_dates = [e["date"] for e in engine.history]
+        for expected, got in zip(dates, recorded_dates):
+            assert expected == got
+
+    def test_empty_history_before_run(self, small_market_data):
+        portfolio = Portfolio(cash=1_000.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        assert engine.history == []
+
+
+# ---------------------------------------------------------------------------
+# Cash-only portfolio (no positions)
+# ---------------------------------------------------------------------------
+
+class TestCashOnlyPortfolio:
+    def test_value_equals_cash_when_no_positions(self, small_market_data):
+        cash = 15_000.0
+        portfolio = Portfolio(cash=cash)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        engine.run(small_market_data.prices.index[:10])
+        for entry in engine.history:
+            assert abs(entry["value"] - cash) < 1e-6, (
+                f"Cash-only portfolio value changed on {entry['date']}: "
+                f"expected {cash}, got {entry['value']}"
+            )
+
+    def test_leverage_is_one_without_margin(self, small_market_data):
+        portfolio = Portfolio(cash=10_000.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        engine.run(small_market_data.prices.index[:5])
+        for entry in engine.history:
+            assert abs(entry["leverage"] - 1.0) < 1e-9, (
+                f"Leverage should be 1.0 without margin, got {entry['leverage']}"
+            )
+
+    def test_cash_allocation_equals_full_value(self, small_market_data):
+        cash = 8_000.0
+        portfolio = Portfolio(cash=cash)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        engine.run(small_market_data.prices.index[:3])
+        for entry in engine.history:
+            assert abs(entry["allocations"]["cash"] - cash) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Strategy interaction
+# ---------------------------------------------------------------------------
+
+class TestStrategyInteraction:
+    def test_strategy_on_date_called_for_every_date(self, small_market_data):
+        called_dates = []
+
+        class _RecordingStrategy:
+            def __init__(self, md):
+                self.market_data = md
+
+            def on_date(self, date):
+                called_dates.append(date)
+
+        portfolio = Portfolio(cash=1_000.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_RecordingStrategy(small_market_data),
+        )
+        dates = small_market_data.prices.index[:20]
+        engine.run(dates)
+        assert len(called_dates) == len(dates)
+        for expected, got in zip(dates, called_dates):
+            assert expected == got
+
+    def test_run_with_zero_dates(self, small_market_data):
+        portfolio = Portfolio(cash=1_000.0)
+        engine = BacktestEngine(
+            portfolio=portfolio,
+            strategy=_NoopStrategy(small_market_data),
+        )
+        engine.run([])  # should not raise
+        assert engine.history == []

--- a/tests/test_performance_metrics.py
+++ b/tests/test_performance_metrics.py
@@ -1,0 +1,384 @@
+"""
+Unit tests for reporting/performance_metrics.py.
+"""
+
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from reporting.performance_metrics import (
+    alpha_beta,
+    annualized_tracking_error,
+    average_monthly_turnover,
+    compute_all_metrics,
+    information_ratio,
+    max_drawdown,
+    drawdown_duration,
+    sharpe_ratio,
+    sortino_ratio,
+    write_summary_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bdate_series(values, start="2022-01-03"):
+    idx = pd.bdate_range(start, periods=len(values))
+    return pd.Series(values, index=idx)
+
+
+# ---------------------------------------------------------------------------
+# sharpe_ratio
+# ---------------------------------------------------------------------------
+
+class TestSharpeRatio:
+    def test_positive_constant_return_positive_sharpe(self):
+        r = _bdate_series([0.001] * 252)
+        assert sharpe_ratio(r) > 0
+
+    def test_negative_constant_return_negative_sharpe(self):
+        r = _bdate_series([-0.001] * 252)
+        assert sharpe_ratio(r) < 0
+
+    def test_zero_volatility_returns_nan(self):
+        r = _bdate_series([0.0] * 100)
+        assert math.isnan(sharpe_ratio(r))
+
+    def test_single_observation_returns_nan(self):
+        r = pd.Series([0.01])
+        assert math.isnan(sharpe_ratio(r))
+
+    def test_zero_risk_free_equals_default(self):
+        np.random.seed(1)
+        r = _bdate_series(np.random.normal(0.0005, 0.015, 252))
+        assert abs(sharpe_ratio(r, risk_free=0.0) - sharpe_ratio(r)) < 1e-12
+
+    def test_higher_risk_free_lowers_sharpe(self):
+        r = _bdate_series([0.001] * 252)
+        assert sharpe_ratio(r, risk_free=0.05) < sharpe_ratio(r, risk_free=0.0)
+
+
+# ---------------------------------------------------------------------------
+# sortino_ratio
+# ---------------------------------------------------------------------------
+
+class TestSortinoRatio:
+    def test_all_positive_returns_inf(self):
+        r = _bdate_series([0.001] * 100)
+        assert sortino_ratio(r) == float("inf")
+
+    def test_mixed_returns_finite(self):
+        np.random.seed(2)
+        r = _bdate_series(np.random.normal(0.0005, 0.015, 252))
+        s = sortino_ratio(r)
+        assert math.isfinite(s)
+
+    def test_single_observation_returns_nan(self):
+        r = pd.Series([0.01])
+        assert math.isnan(sortino_ratio(r))
+
+    def test_higher_downside_lower_sortino(self):
+        """A series with more downside should have a lower Sortino ratio."""
+        np.random.seed(3)
+        base = np.random.normal(0.001, 0.010, 252)
+        noisy = base - np.abs(np.random.normal(0, 0.005, 252))
+        s_base = sortino_ratio(_bdate_series(base))
+        s_noisy = sortino_ratio(_bdate_series(noisy))
+        assert s_base > s_noisy
+
+
+# ---------------------------------------------------------------------------
+# max_drawdown
+# ---------------------------------------------------------------------------
+
+class TestMaxDrawdown:
+    def test_monotonically_rising_gives_zero(self):
+        v = pd.Series([100, 110, 120, 130], index=pd.date_range("2022-01-01", periods=4))
+        assert max_drawdown(v) == 0.0
+
+    def test_simple_50_percent_drawdown(self):
+        v = pd.Series([200, 100], index=pd.date_range("2022-01-01", periods=2))
+        assert abs(max_drawdown(v) - 0.5) < 1e-9
+
+    def test_recover_after_drawdown(self):
+        v = pd.Series([100, 80, 90, 120], index=pd.date_range("2022-01-01", periods=4))
+        # peak=100, trough=80, dd = 20/100 = 0.20
+        assert abs(max_drawdown(v) - 0.20) < 1e-9
+
+    def test_short_series_returns_zero(self):
+        v = pd.Series([100], index=pd.date_range("2022-01-01", periods=1))
+        assert max_drawdown(v) == 0.0
+
+    def test_result_is_non_negative(self):
+        np.random.seed(4)
+        v = pd.Series(100 * np.cumprod(1 + np.random.normal(0, 0.01, 252)),
+                      index=pd.bdate_range("2022-01-03", periods=252))
+        assert max_drawdown(v) >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# drawdown_duration
+# ---------------------------------------------------------------------------
+
+class TestDrawdownDuration:
+    def test_no_drawdown_zero_duration(self):
+        v = pd.Series([100, 110, 120], index=pd.date_range("2022-01-01", periods=3))
+        assert drawdown_duration(v) == 0
+
+    def test_closed_drawdown_duration(self):
+        idx = pd.date_range("2022-01-01", periods=5, freq="D")
+        # Drawdown starts on day 1, recovers on day 4
+        v = pd.Series([100, 90, 85, 95, 105], index=idx)
+        dur = drawdown_duration(v)
+        assert dur > 0
+
+    def test_open_drawdown_counts_to_last_date(self):
+        idx = pd.date_range("2022-01-01", periods=4, freq="D")
+        v = pd.Series([100, 90, 80, 70], index=idx)
+        dur = drawdown_duration(v)
+        # Drawdown starts on Jan 2 (first date below peak=100).
+        # duration = (last_date - current_start).days = (Jan 4 - Jan 2) = 2 calendar days.
+        assert dur == 2
+
+    def test_short_series_returns_zero(self):
+        v = pd.Series([100], index=pd.date_range("2022-01-01", periods=1))
+        assert drawdown_duration(v) == 0
+
+
+# ---------------------------------------------------------------------------
+# alpha_beta
+# ---------------------------------------------------------------------------
+
+class TestAlphaBeta:
+    def test_identical_returns_zero_alpha_unit_beta(self):
+        np.random.seed(5)
+        idx = pd.bdate_range("2022-01-03", periods=200)
+        b = pd.Series(np.random.normal(0, 0.01, 200), index=idx)
+        alpha, beta = alpha_beta(b, b)
+        assert abs(beta - 1.0) < 1e-6
+        assert abs(alpha) < 1e-2  # essentially zero after annualization
+
+    def test_too_few_observations_returns_nan(self):
+        p = pd.Series([0.01, 0.02, 0.03])
+        b = pd.Series([0.01, 0.02, 0.03])
+        alpha, beta = alpha_beta(p, b)
+        assert math.isnan(alpha)
+        assert math.isnan(beta)
+
+    def test_returns_tuple_of_two(self):
+        np.random.seed(6)
+        idx = pd.bdate_range("2022-01-03", periods=50)
+        p = pd.Series(np.random.normal(0, 0.01, 50), index=idx)
+        b = pd.Series(np.random.normal(0, 0.01, 50), index=idx)
+        result = alpha_beta(p, b)
+        assert len(result) == 2
+
+    def test_no_common_dates_returns_nan(self):
+        p = pd.Series([0.01] * 20, index=pd.bdate_range("2022-01-03", periods=20))
+        b = pd.Series([0.01] * 20, index=pd.bdate_range("2023-01-03", periods=20))
+        alpha, beta = alpha_beta(p, b)
+        assert math.isnan(alpha)
+
+
+# ---------------------------------------------------------------------------
+# information_ratio
+# ---------------------------------------------------------------------------
+
+class TestInformationRatio:
+    def test_identical_returns_nan(self):
+        idx = pd.bdate_range("2022-01-03", periods=100)
+        r = pd.Series([0.001] * 100, index=idx)
+        assert math.isnan(information_ratio(r, r))
+
+    def test_constant_outperformance_positive_ir(self):
+        idx = pd.bdate_range("2022-01-03", periods=252)
+        np.random.seed(7)
+        b = pd.Series(np.random.normal(0.0003, 0.01, 252), index=idx)
+        p = b + 0.0005  # constant daily outperformance
+        ir = information_ratio(p, b)
+        assert ir > 0
+
+    def test_constant_underperformance_negative_ir(self):
+        idx = pd.bdate_range("2022-01-03", periods=252)
+        np.random.seed(8)
+        b = pd.Series(np.random.normal(0.0003, 0.01, 252), index=idx)
+        p = b - 0.0005
+        assert information_ratio(p, b) < 0
+
+
+# ---------------------------------------------------------------------------
+# annualized_tracking_error
+# ---------------------------------------------------------------------------
+
+class TestAnnualizedTrackingError:
+    def test_identical_returns_zero_te(self):
+        idx = pd.bdate_range("2022-01-03", periods=100)
+        r = pd.Series([0.001] * 100, index=idx)
+        assert annualized_tracking_error(r, r) == 0.0
+
+    def test_te_is_positive(self):
+        np.random.seed(9)
+        idx = pd.bdate_range("2022-01-03", periods=100)
+        p = pd.Series(np.random.normal(0, 0.01, 100), index=idx)
+        b = pd.Series(np.random.normal(0, 0.01, 100), index=idx)
+        assert annualized_tracking_error(p, b) > 0
+
+    def test_higher_divergence_higher_te(self):
+        idx = pd.bdate_range("2022-01-03", periods=252)
+        np.random.seed(10)
+        b = pd.Series(np.random.normal(0, 0.01, 252), index=idx)
+        p_close = b + np.random.normal(0, 0.001, 252)   # small tracking
+        p_far = b + np.random.normal(0, 0.02, 252)       # large tracking
+        te_close = annualized_tracking_error(_bdate_series(p_close.values), b)
+        te_far = annualized_tracking_error(_bdate_series(p_far.values), b)
+        assert te_far > te_close
+
+    def test_short_series_returns_nan(self):
+        p = pd.Series([0.01])
+        b = pd.Series([0.01])
+        assert math.isnan(annualized_tracking_error(p, b))
+
+
+# ---------------------------------------------------------------------------
+# average_monthly_turnover
+# ---------------------------------------------------------------------------
+
+class TestAverageMonthlyTurnover:
+    def test_no_trades_returns_zero(self):
+        assert average_monthly_turnover([], []) == 0.0
+
+    def test_empty_trades_list_returns_zero(self):
+        idx = pd.bdate_range("2022-01-03", periods=20)
+        history = [{"date": d, "value": 10_000.0} for d in idx]
+        assert average_monthly_turnover([], history) == 0.0
+
+    def test_basic_turnover_is_non_negative(self):
+        idx = pd.bdate_range("2022-01-03", periods=252)
+        history = [{"date": d, "value": 20_000.0} for d in idx]
+        trades = [
+            {"type": "buy", "date": pd.Timestamp("2022-01-05"), "ticker": "A",
+             "shares": 10, "price": 100, "amount": 1000.0},
+        ]
+        to = average_monthly_turnover(trades, history)
+        assert to >= 0.0
+
+    def test_known_turnover_calculation(self):
+        # Portfolio always at 10000. One month, 1000 traded → turnover = 10%
+        idx = pd.bdate_range("2022-01-03", periods=22)
+        history = [{"date": d, "value": 10_000.0} for d in idx]
+        trades = [
+            {"type": "buy", "date": pd.Timestamp("2022-01-05"),
+             "ticker": "A", "shares": 5, "price": 200, "amount": 1000.0},
+        ]
+        to = average_monthly_turnover(trades, history)
+        assert abs(to - 0.10) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# compute_all_metrics
+# ---------------------------------------------------------------------------
+
+class TestComputeAllMetrics:
+    def test_returns_dict(self, small_spy_prices, trading_dates):
+        history = [{"date": d, "value": 20_000 + i * 5} for i, d in enumerate(trading_dates[:100])]
+        metrics = compute_all_metrics(history, [], small_spy_prices, 20_000.0)
+        assert isinstance(metrics, dict)
+
+    def test_expected_keys_present(self, small_spy_prices, trading_dates):
+        history = [{"date": d, "value": 20_000.0 + i} for i, d in enumerate(trading_dates[:200])]
+        metrics = compute_all_metrics(history, [], small_spy_prices, 20_000.0)
+        expected_keys = [
+            "annualized_return_pct", "sharpe_ratio", "sortino_ratio",
+            "max_drawdown_pct", "max_drawdown_duration_days",
+            "alpha_annualized", "beta", "information_ratio",
+            "annualized_tracking_error_pct", "avg_monthly_turnover_pct",
+        ]
+        for key in expected_keys:
+            assert key in metrics, f"Missing key: {key}"
+
+    def test_empty_history_returns_empty_dict(self, small_spy_prices):
+        result = compute_all_metrics([], [], small_spy_prices, 20_000.0)
+        assert result == {}
+
+    def test_single_entry_returns_empty_dict(self, small_spy_prices, trading_dates):
+        history = [{"date": trading_dates[0], "value": 20_000.0}]
+        result = compute_all_metrics(history, [], small_spy_prices, 20_000.0)
+        assert result == {}
+
+    def test_monotonic_increase_positive_return(self, small_spy_prices, trading_dates):
+        history = [{"date": d, "value": 20_000 + i * 10} for i, d in enumerate(trading_dates)]
+        metrics = compute_all_metrics(history, [], small_spy_prices, 20_000.0)
+        assert metrics["annualized_return_pct"] > 0
+        assert metrics["max_drawdown_pct"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# write_summary_report
+# ---------------------------------------------------------------------------
+
+class TestWriteSummaryReport:
+    def test_creates_file(self, tmp_path, small_spy_prices, trading_dates):
+        history = [{"date": d, "value": 20_000.0 + i} for i, d in enumerate(trading_dates[:100])]
+        metrics = compute_all_metrics(history, [], small_spy_prices, 20_000.0)
+        out = str(tmp_path / "summary.txt")
+        write_summary_report(metrics, output_path=out)
+        assert os.path.exists(out)
+
+    def test_file_contains_header(self, tmp_path, small_spy_prices, trading_dates):
+        history = [{"date": d, "value": 20_000.0 + i} for i, d in enumerate(trading_dates[:100])]
+        metrics = compute_all_metrics(history, [], small_spy_prices, 20_000.0)
+        out = str(tmp_path / "summary2.txt")
+        write_summary_report(metrics, output_path=out)
+        content = open(out).read()
+        assert "PERFORMANCE SUMMARY" in content
+
+    def test_file_contains_sharpe_label(self, tmp_path, small_spy_prices, trading_dates):
+        history = [{"date": d, "value": 20_000.0 + i * 5} for i, d in enumerate(trading_dates[:200])]
+        metrics = compute_all_metrics(history, [], small_spy_prices, 20_000.0)
+        out = str(tmp_path / "summary3.txt")
+        write_summary_report(metrics, output_path=out)
+        content = open(out).read()
+        assert "Sharpe" in content
+
+    def test_nan_metrics_handled_gracefully(self, tmp_path):
+        """write_summary_report must not crash when metrics contain nan values."""
+        metrics = {
+            "annualized_return_pct": float("nan"),
+            "sharpe_ratio": float("nan"),
+            "sortino_ratio": float("inf"),
+            "max_drawdown_pct": 0.0,
+            "max_drawdown_duration_days": 0,
+            "alpha_annualized": float("nan"),
+            "beta": float("nan"),
+            "information_ratio": float("nan"),
+            "annualized_tracking_error_pct": float("nan"),
+            "avg_monthly_turnover_pct": 0.0,
+        }
+        out = str(tmp_path / "summary_nan.txt")
+        write_summary_report(metrics, output_path=out)  # must not raise
+        assert os.path.exists(out)
+
+    def test_creates_parent_directory(self, tmp_path):
+        metrics = {
+            "annualized_return_pct": 5.0,
+            "sharpe_ratio": 1.0,
+            "sortino_ratio": 1.5,
+            "max_drawdown_pct": 10.0,
+            "max_drawdown_duration_days": 30,
+            "alpha_annualized": 0.01,
+            "beta": 0.95,
+            "information_ratio": 0.5,
+            "annualized_tracking_error_pct": 3.0,
+            "avg_monthly_turnover_pct": 2.0,
+        }
+        nested = str(tmp_path / "nested" / "dir" / "summary.txt")
+        write_summary_report(metrics, output_path=nested)
+        assert os.path.exists(nested)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for FactorReplicationStrategy.
+
+Tests use the synthetic fixtures from conftest.py so no network calls are made.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from config import MarginConfig, TaxConfig, TradingCostConfig
+from decisions.decision_engine import DecisionEngine
+from execution.executor import Executor
+from factors.factor_model import FactorModel
+from portfolio.portfolio import Portfolio
+from strategy.strategy import FactorReplicationStrategy
+from targets.factor_target import FactorTarget
+from tax.tax_engine import TaxEngine
+from trading.margin_cost import MarginCostModel
+from universe.universe_selector import UniverseSelector
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal FactorReplicationStrategy
+# ---------------------------------------------------------------------------
+
+def _make_strategy(market_data, factor_returns, cash=20_000.0):
+    tax_engine = TaxEngine()
+    margin_config = MarginConfig(enabled=False)
+    decision_engine = DecisionEngine(
+        tax_engine=tax_engine,
+        trading_cost_config=TradingCostConfig(),
+        margin_config=margin_config,
+        margin_cost_model=MarginCostModel(),
+    )
+    portfolio = Portfolio(cash=cash)
+    executor = Executor(market_data)
+    target = FactorTarget({"Value": 0.6, "Momentum": 0.4})
+    universe_selector = UniverseSelector(min_r2=0.1)
+    factor_model = FactorModel(factor_returns)
+    strategy = FactorReplicationStrategy(
+        market_data=market_data,
+        factor_model=factor_model,
+        universe_selector=universe_selector,
+        target=target,
+        portfolio=portfolio,
+        decision_engine=decision_engine,
+        executor=executor,
+        margin_config=margin_config,
+        margin_cost_model=MarginCostModel(),
+    )
+    return strategy, portfolio, executor
+
+
+# ---------------------------------------------------------------------------
+# _is_rebalance_date
+# ---------------------------------------------------------------------------
+
+class TestIsRebalanceDate:
+    def test_first_call_always_triggers_rebalance(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        assert strategy._is_rebalance_date(pd.Timestamp("2022-01-03"))
+
+    def test_same_month_skips_rebalance(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.last_rebalance_date = pd.Timestamp("2022-01-03")
+        assert not strategy._is_rebalance_date(pd.Timestamp("2022-01-20"))
+
+    def test_next_month_triggers_rebalance(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.last_rebalance_date = pd.Timestamp("2022-01-03")
+        assert strategy._is_rebalance_date(pd.Timestamp("2022-02-01"))
+
+    def test_same_day_skips(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.last_rebalance_date = pd.Timestamp("2022-03-15")
+        assert not strategy._is_rebalance_date(pd.Timestamp("2022-03-15"))
+
+    def test_year_boundary_triggers_rebalance(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.last_rebalance_date = pd.Timestamp("2022-12-30")
+        assert strategy._is_rebalance_date(pd.Timestamp("2023-01-03"))
+
+
+# ---------------------------------------------------------------------------
+# _portfolio_factor_exposure
+# ---------------------------------------------------------------------------
+
+class TestPortfolioFactorExposure:
+    def test_empty_portfolio_returns_zero_vector(self, small_market_data, small_factor_returns):
+        strategy, portfolio, _ = _make_strategy(small_market_data, small_factor_returns)
+        assert len(portfolio.positions) == 0
+
+        tickers = small_market_data.prices.columns.tolist()
+        factor_names = small_factor_returns.columns.tolist()
+        exposures = pd.DataFrame(
+            np.zeros((len(tickers), len(factor_names))),
+            index=tickers,
+            columns=factor_names,
+        )
+        result = strategy._portfolio_factor_exposure(exposures, pd.Timestamp("2022-01-03"))
+        assert np.allclose(result, np.zeros(len(factor_names)))
+
+    def test_single_position_returns_its_exposure(self, small_market_data, small_factor_returns):
+        from portfolio.lots import Lot
+
+        strategy, portfolio, executor = _make_strategy(small_market_data, small_factor_returns)
+        date = pd.Timestamp("2022-01-03")
+        # Buy 10 shares of AAPL at whatever the price is on that date
+        executor.buy(portfolio, "AAPL", 1000.0, date)
+
+        factor_names = small_factor_returns.columns.tolist()
+        exposures = pd.DataFrame(
+            {
+                "AAPL": [1.0, 0.5, 0.3],
+                "MSFT": [0.8, 0.2, 0.4],
+            },
+            index=factor_names,
+        ).T
+        result = strategy._portfolio_factor_exposure(exposures, date)
+        # Only AAPL is in the portfolio, so exposure should equal AAPL's row
+        assert np.allclose(result, exposures.loc["AAPL"].values)
+
+
+# ---------------------------------------------------------------------------
+# _realized_gains_ytd
+# ---------------------------------------------------------------------------
+
+class TestRealizedGainsYTD:
+    def test_empty_gains_list_returns_zero(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        assert strategy._realized_gains_ytd(pd.Timestamp("2022-06-01")) == 0.0
+
+    def test_only_current_year_is_summed(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.realized_gains = [
+            {"date": pd.Timestamp("2022-03-01"), "realized_gain": 500.0},
+            {"date": pd.Timestamp("2022-08-15"), "realized_gain": 200.0},
+            {"date": pd.Timestamp("2021-12-31"), "realized_gain": 1000.0},  # prior year
+        ]
+        total = strategy._realized_gains_ytd(pd.Timestamp("2022-10-01"))
+        assert abs(total - 700.0) < 1e-9
+
+    def test_negative_gains_included(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.realized_gains = [
+            {"date": pd.Timestamp("2022-04-01"), "realized_gain": 800.0},
+            {"date": pd.Timestamp("2022-06-01"), "realized_gain": -300.0},
+        ]
+        assert abs(strategy._realized_gains_ytd(pd.Timestamp("2022-07-01")) - 500.0) < 1e-9
+
+    def test_future_gains_excluded(self, small_market_data, small_factor_returns):
+        """Gains in the same year but after the query date are still included (YTD = full year)."""
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.realized_gains = [
+            {"date": pd.Timestamp("2022-11-01"), "realized_gain": 100.0},
+        ]
+        # query date in 2022 — same year → included
+        assert abs(strategy._realized_gains_ytd(pd.Timestamp("2022-01-31")) - 100.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# _conviction_score
+# ---------------------------------------------------------------------------
+
+class TestConvictionScore:
+    def test_high_r2_high_te_gives_high_score(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        r2 = pd.Series({"A": 1.0, "B": 1.0})
+        score = strategy._conviction_score(r2, tracking_error=1.0)
+        assert abs(score - 1.0) < 1e-9
+
+    def test_score_is_bounded_at_one(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        r2 = pd.Series({"A": 0.9, "B": 0.8})
+        # tracking_error > 1 → te_score capped at 1.0
+        score = strategy._conviction_score(r2, tracking_error=5.0)
+        assert 0.0 <= score <= 1.0
+
+    def test_zero_r2_gives_zero_score(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        r2 = pd.Series({"A": 0.0, "B": 0.0})
+        assert strategy._conviction_score(r2, tracking_error=1.0) == 0.0
+
+    def test_zero_tracking_error_gives_zero_score(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        r2 = pd.Series({"A": 0.9, "B": 0.8})
+        assert strategy._conviction_score(r2, tracking_error=0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _lookback_start
+# ---------------------------------------------------------------------------
+
+class TestLookbackStart:
+    def test_default_252_day_lookback(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        date = pd.Timestamp("2022-06-01")
+        start = strategy._lookback_start(date)
+        assert (date - start).days == 252
+
+    def test_custom_lookback(self, small_market_data, small_factor_returns):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        strategy.lookback_days = 100
+        date = pd.Timestamp("2022-06-01")
+        start = strategy._lookback_start(date)
+        assert (date - start).days == 100
+
+
+# ---------------------------------------------------------------------------
+# on_date — smoke test over a short date window
+# ---------------------------------------------------------------------------
+
+class TestOnDate:
+    def test_runs_first_60_days_without_error(self, small_market_data, small_factor_returns, trading_dates):
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        for d in trading_dates[:60]:
+            strategy.on_date(d)  # must not raise
+
+    def test_exposure_history_grows_monthly(self, small_market_data, small_factor_returns, trading_dates):
+        """Exposure snapshots should be added once per rebalance (monthly frequency)."""
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        # Run 6 months (≈ 126 trading days)
+        for d in trading_dates[:126]:
+            strategy.on_date(d)
+        # Expect roughly 6 rebalance snapshots (one per month)
+        assert 4 <= len(strategy.exposure_history) <= 8
+
+    def test_no_rebalance_on_non_rebalance_days(self, small_market_data, small_factor_returns, trading_dates):
+        """last_rebalance_date should only update on actual rebalance days."""
+        strategy, _, _ = _make_strategy(small_market_data, small_factor_returns)
+        # Run just the first two trading days (same month → only first should rebalance)
+        strategy.on_date(trading_dates[0])
+        first_rebalance = strategy.last_rebalance_date
+        strategy.on_date(trading_dates[1])
+        # Second day is same month → last_rebalance_date should NOT change if no rebalance
+        # (it would change only if decision engine approved another rebalance, which won't
+        # happen since on_date returns early for non-rebalance dates)
+        assert strategy.last_rebalance_date == first_rebalance


### PR DESCRIPTION
…ive tests

Performance metrics (reporting/performance_metrics.py):
- Sharpe ratio, Sortino ratio (risk-adjusted return)
- Max drawdown and drawdown duration
- Alpha, beta, information ratio, annualised tracking error vs SPY
- Average monthly turnover
- write_summary_report() produces reports/summary.txt

Rolling factor exposures:
- strategy.py captures exposure_history at each rebalance date
- charts.py adds _plot_rolling_factor_exposures() (4th chart)
- main.py wires exposure_history into plot_results() and computes/writes metrics

Test suite additions:
- tests/conftest.py: session-scoped synthetic fixtures (5 tickers, 2 years, no yfinance) with warmup history so lookback windows are always populated
- tests/test_backtest_integration.py: full end-to-end pipeline test covering portfolio value, realized gains, harvest event months, and exposure history
- tests/test_strategy.py: unit tests for _is_rebalance_date, _portfolio_factor_ exposure, _realized_gains_ytd, _conviction_score, _lookback_start, on_date
- tests/test_engine.py: unit tests for BacktestEngine history recording, cash-only portfolios, leverage, and strategy interaction
- tests/test_performance_metrics.py: unit tests for all metric functions and write_summary_report (including nan/inf edge cases)

Closes #18