### PR TITLE
Add progress prints throughout script execution

### DIFF
--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -6,7 +6,11 @@ class BacktestEngine:
 
     def run(self, dates):
         market_data = self.strategy.market_data
+        current_year = None
         for d in dates:
+            if d.year != current_year:
+                current_year = d.year
+                print(f"  {current_year}...", flush=True)
             self.strategy.on_date(d)
             value = self.portfolio.market_value(market_data, d)
             leverage = self.portfolio.leverage_ratio(market_data, d)

--- a/data/market_data.py
+++ b/data/market_data.py
@@ -75,6 +75,7 @@ class MarketData:
 
         # Include SPY for benchmark comparison; extract and remove before constructing MarketData
         download_tickers = list(tickers) + ["SPY"]
+        print(f"  Downloading prices for {len(download_tickers)} tickers from {warmup_start}...", flush=True)
         raw = yf.download(download_tickers, start=warmup_start, end=end, auto_adjust=True, progress=False)
         prices_full = raw["Close"] if len(download_tickers) > 1 else raw["Close"].to_frame(download_tickers[0])
         prices_full = prices_full.dropna(how="all")
@@ -88,7 +89,9 @@ class MarketData:
         # Compute returns over the full history (needed for lookback)
         returns_full = prices_full.pct_change().dropna(how="all")
 
+        print(f"  Loaded {prices_full.shape[1] - 1} tickers × {prices_full.shape[0]} days", flush=True)
         # Download Fama-French daily factors (Value = HML, Momentum = UMD)
+        print("  Downloading Fama-French factors...", flush=True)
         ff = _fetch_ff_csv(_FF_FACTORS_URL, warmup_start, end)
         mom = _fetch_ff_csv(_FF_MOMENTUM_URL, warmup_start, end)
 

--- a/main.py
+++ b/main.py
@@ -23,17 +23,20 @@ def main():
     # --------------------------------------------------
     # 1. Load data (NO logic here)
     # --------------------------------------------------
+    print("Selecting ticker universe...")
     ticker_universe = TickerUniverse()
     tickers = ticker_universe.select(
         regions=["US", "Europe", "Asia-Pacific"],
         cap_tiers=["mega", "large"],
         min_adv=1e8,
     )
+    print(f"  {len(tickers)} tickers selected")
     market_data, factor_returns, spy_prices = MarketData.from_tickers(tickers, start="2020-01-01")
 
     # --------------------------------------------------
     # 2. Initialize models
     # --------------------------------------------------
+    print("Initializing models...")
     factor_model = FactorModel(factor_returns)
     universe_selector = UniverseSelector(min_r2=0.3)
 
@@ -91,6 +94,10 @@ def main():
         strategy=strategy
     )
 
+    n_days = len(market_data.prices.index)
+    start_date = market_data.prices.index[0].date()
+    end_date = market_data.prices.index[-1].date()
+    print(f"\nRunning backtest  ({start_date} → {end_date},  {n_days} trading days)")
     backtest.run(market_data.prices.index)
 
     # --------------------------------------------------

--- a/strategy/strategy.py
+++ b/strategy/strategy.py
@@ -125,6 +125,7 @@ class FactorReplicationStrategy:
 
         self._rebalance_portfolio(universe, exposures, date)
         self.last_rebalance_date = date
+        print(f"    [rebalance] {date.date()}  universe={len(universe)}  TE={tracking_error:.3f}  value=€{portfolio_value:,.0f}", flush=True)
 
         # Repay any margin balance that can be covered by spare cash
         if self.margin_config is not None and self.margin_config.enabled \


### PR DESCRIPTION
## Summary
- Prints ticker count and download status during data loading
- Shows Fama-French factor download progress
- Prints year-by-year progress during the backtest loop
- Logs each rebalance event with date, universe size, tracking error, and portfolio value

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)