### PR TITLE
Add Bayesian hyperparameter tuning via SSH

### DIFF
--- a/backtest/runner.py
+++ b/backtest/runner.py
@@ -1,0 +1,105 @@
+# backtest/runner.py
+
+from config import BacktestConfig
+from data.market_data import MarketData
+from factors.factor_model import FactorModel
+from universe.universe_selector import UniverseSelector
+from universe.ticker_universe import TickerUniverse
+from targets.factor_target import FactorTarget
+from portfolio.portfolio import Portfolio
+from tax.tax_engine import TaxEngine
+from tax.tax_harvesting import TaxHarvestingEngine
+from trading.margin_cost import MarginCostModel
+from decisions.decision_engine import DecisionEngine
+from execution.executor import Executor
+from optimizer.factor_replication_optimizer import FactorReplicationOptimizer
+from strategy.strategy import FactorReplicationStrategy
+from backtest.engine import BacktestEngine
+from reporting.performance_metrics import compute_all_metrics
+
+
+def run_backtest(config: BacktestConfig) -> dict:
+    """Runs the full pipeline and returns the metrics dict from compute_all_metrics()."""
+
+    # 1. Ticker universe + data download
+    print("Selecting ticker universe...")
+    ticker_universe = TickerUniverse()
+    tickers = ticker_universe.select(
+        regions=config.regions,
+        cap_tiers=config.cap_tiers,
+        min_adv=config.min_adv,
+    )
+    print(f"  {len(tickers)} tickers selected")
+    market_data, factor_returns, spy_prices = MarketData.from_tickers(
+        tickers, start=config.start
+    )
+
+    # 2. Model initialisation
+    print("Initializing models...")
+    factor_model = FactorModel(factor_returns)
+    universe_selector = UniverseSelector(min_r2=config.min_r2)
+    target = FactorTarget(config.target_weights)
+
+    # 3. Portfolio & infrastructure
+    portfolio = Portfolio(cash=config.initial_cash)
+
+    tax_engine = TaxEngine(config=config.tax_config)
+    margin_cost_model = MarginCostModel()
+    decision_engine = DecisionEngine(
+        tax_engine=tax_engine,
+        trading_cost_config=config.trading_cost_config,
+        margin_config=config.margin_config,
+        margin_cost_model=margin_cost_model,
+    )
+    executor = Executor(market_data)
+    harvester = TaxHarvestingEngine(
+        config=config.tax_config,
+        tax_engine=tax_engine,
+        executor=executor,
+    )
+    optimizer = FactorReplicationOptimizer()
+
+    # 4. Strategy
+    strategy = FactorReplicationStrategy(
+        market_data=market_data,
+        factor_model=factor_model,
+        universe_selector=universe_selector,
+        target=target,
+        portfolio=portfolio,
+        decision_engine=decision_engine,
+        executor=executor,
+        optimizer=optimizer,
+        harvester=harvester,
+        margin_config=config.margin_config,
+        margin_cost_model=margin_cost_model,
+        rebalance_frequency=config.rebalance_frequency,
+        lookback_days=config.lookback_days,
+    )
+
+    # 5. Backtest
+    backtest = BacktestEngine(portfolio=portfolio, strategy=strategy)
+
+    n_days = len(market_data.prices.index)
+    start_date = market_data.prices.index[0].date()
+    end_date = market_data.prices.index[-1].date()
+    print(f"\nRunning backtest  ({start_date} → {end_date},  {n_days} trading days)")
+    backtest.run(market_data.prices.index)
+
+    # 6. Compute and return metrics
+    metrics = compute_all_metrics(
+        history=backtest.history,
+        trades=executor.trades,
+        spy_prices=spy_prices,
+        initial_value=config.initial_cash,
+    )
+
+    # Attach extra context the caller may want for reporting
+    metrics["_backtest"] = backtest
+    metrics["_strategy"] = strategy
+    metrics["_portfolio"] = portfolio
+    metrics["_market_data"] = market_data
+    metrics["_executor"] = executor
+    metrics["_spy_prices"] = spy_prices
+    metrics["_initial_value"] = config.initial_cash
+
+    return metrics

--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ class TaxConfig:
     wash_sale_waiting_days: int = 30        # Days before repurchasing the same ticker
     max_harvest_per_year: float = float("inf")  # Cap on losses harvested annually (€)
 
+
 @dataclass
 class TradingCostConfig:
     pct_cost: float = 0.001
@@ -29,3 +30,26 @@ class MarginConfig:
     annual_rate: float = 0.05
     conviction_threshold: float = 0.8   # min [0,1] conviction score to trigger borrowing
     expected_hold_days: int = 90        # horizon for tax-aware borrow vs. sell comparison
+
+
+@dataclass
+class BacktestConfig:
+    # Data
+    start: str = "2020-01-01"
+    lookback_days: int = 252
+    # Universe
+    regions: list = field(default_factory=lambda: ["US", "Europe", "Asia-Pacific"])
+    cap_tiers: list = field(default_factory=lambda: ["mega", "large"])
+    min_adv: float = 1e8
+    # Factor model
+    min_r2: float = 0.3
+    # Target
+    target_weights: dict = field(default_factory=lambda: {"Value": 0.6, "Momentum": 0.4})
+    # Strategy
+    rebalance_frequency: str = "M"
+    # Portfolio
+    initial_cash: float = 20_000.0
+    # Sub-configs (use defaults if not set)
+    tax_config: TaxConfig = field(default_factory=TaxConfig)
+    trading_cost_config: TradingCostConfig = field(default_factory=TradingCostConfig)
+    margin_config: MarginConfig = field(default_factory=MarginConfig)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ yfinance
 requests
 matplotlib
 pytest
+paramiko
+optuna

--- a/tune/objective.py
+++ b/tune/objective.py
@@ -1,0 +1,32 @@
+# tune/objective.py
+
+"""
+Composite scoring function for portfolio backtest results.
+
+Higher score is better. Weights:
+  +0.5 × Sharpe ratio
+  +0.3 × annualized return (fraction, not %)
+  -0.2 × max drawdown (fraction, not %)
+"""
+
+WEIGHTS = {
+    "sharpe_ratio":            0.5,
+    "annualized_return_pct":   0.3,
+    "max_drawdown_pct":       -0.2,
+}
+
+
+def compute_score(metrics: dict) -> float:
+    """Return composite score from a metrics dict produced by compute_all_metrics()."""
+    sharpe = metrics.get("sharpe_ratio", 0.0)
+    ret    = metrics.get("annualized_return_pct", 0.0) / 100
+    dd     = abs(metrics.get("max_drawdown_pct", 0.0)) / 100
+
+    if sharpe != sharpe:   # NaN guard
+        sharpe = 0.0
+    if ret != ret:
+        ret = 0.0
+    if dd != dd:
+        dd = 0.0
+
+    return 0.5 * sharpe + 0.3 * ret - 0.2 * dd

--- a/tune/orchestrator.py
+++ b/tune/orchestrator.py
@@ -1,0 +1,80 @@
+# tune/orchestrator.py
+
+"""
+Bayesian optimisation orchestrator using Optuna (TPE sampler).
+
+Each trial:
+  1. Optuna suggests hyperparameters from SEARCH_SPACE
+  2. SSHRunner ships the config to the remote machine
+  3. Remote worker runs run_backtest() and returns metrics JSON
+  4. compute_score() converts metrics to a scalar objective
+  5. Optuna records the score and updates its model
+
+The study is persisted to SQLite so runs can be interrupted and resumed.
+"""
+
+import optuna
+
+from tune.search_space import SEARCH_SPACE
+from tune.objective import compute_score
+from tune.ssh_runner import SSHRunner
+
+
+def sample_params(trial: optuna.Trial) -> dict:
+    """Sample one set of hyperparameters from SEARCH_SPACE."""
+    params = {}
+    for name, spec in SEARCH_SPACE.items():
+        kind = spec[0]
+        if kind == "float":
+            _, low, high = spec
+            params[name] = trial.suggest_float(name, low, high)
+        elif kind == "int":
+            _, low, high = spec
+            params[name] = trial.suggest_int(name, low, high)
+        elif kind == "cat":
+            _, choices = spec
+            params[name] = trial.suggest_categorical(name, choices)
+        else:
+            raise ValueError(f"Unknown search space kind '{kind}' for '{name}'")
+    return params
+
+
+def run_study(
+    n_trials: int,
+    ssh_runner: SSHRunner,
+    study_name: str = "portfolio-tuning",
+    storage: str = "sqlite:///reports/tuning.db",
+) -> optuna.Study:
+    """
+    Run a Bayesian optimisation study.
+
+    Returns the completed Optuna study object (all trials accessible via study.trials).
+    """
+    import os
+    os.makedirs("reports", exist_ok=True)
+
+    study = optuna.create_study(
+        direction="maximize",
+        storage=storage,
+        study_name=study_name,
+        load_if_exists=True,
+    )
+
+    def objective(trial: optuna.Trial) -> float:
+        params = sample_params(trial)
+        try:
+            metrics = ssh_runner.run_trial(params)
+        except Exception as exc:
+            # Log and return a very bad score so Optuna skips this region
+            print(f"[orchestrator] Trial {trial.number} failed: {exc}")
+            raise optuna.exceptions.TrialPruned()
+
+        score = compute_score(metrics)
+        # Attach raw metrics as user attributes for later inspection
+        for key, value in metrics.items():
+            if isinstance(value, (int, float, str, bool)):
+                trial.set_user_attr(key, value)
+        return score
+
+    study.optimize(objective, n_trials=n_trials, n_jobs=1)
+    return study

--- a/tune/search_space.py
+++ b/tune/search_space.py
@@ -1,0 +1,21 @@
+# tune/search_space.py
+
+"""
+Defines the hyperparameter search space for Bayesian optimisation.
+
+Each entry maps a parameter name to a tuple:
+  ("float",  low, high)       — continuous float
+  ("int",    low, high)       — integer
+  ("cat",    [choices...])    — categorical
+
+The sampler (tune/orchestrator.py) reads this dict to build Optuna trial suggestions.
+"""
+
+SEARCH_SPACE = {
+    "value_weight":         ("float", 0.0,   1.0),
+    "momentum_weight":      ("float", 0.0,   1.0),   # clipped so value + momentum <= 1
+    "min_r2":               ("float", 0.1,   0.7),
+    "lookback_days":        ("int",   60,    504),
+    "rebalance_frequency":  ("cat",   ["W",  "M", "Q"]),
+    "trading_cost_pct":     ("float", 0.0005, 0.005),
+}

--- a/tune/ssh_runner.py
+++ b/tune/ssh_runner.py
@@ -1,0 +1,111 @@
+# tune/ssh_runner.py
+
+"""
+Thin SSH utility that ships a trial config to a remote machine and returns metrics.
+
+Credentials are read from environment variables (nothing hard-coded):
+  TUNE_SSH_HOST   — hostname or IP of the remote machine
+  TUNE_SSH_USER   — SSH username
+  TUNE_SSH_REPO   — absolute path to the portfolio repo on the remote machine
+  TUNE_SSH_KEY    — (optional) path to private key file; falls back to ssh-agent / default keys
+
+Usage:
+    runner = SSHRunner.from_env()
+    metrics = runner.run_trial({"value_weight": 0.6, "momentum_weight": 0.4, ...})
+"""
+
+import json
+import os
+import sys
+
+
+class SSHRunner:
+    def __init__(
+        self,
+        host: str,
+        user: str,
+        repo_path: str,
+        key_path: str | None = None,
+    ):
+        self.host = host
+        self.user = user
+        self.repo_path = repo_path
+        self.key_path = key_path
+
+    @classmethod
+    def from_env(cls) -> "SSHRunner":
+        """Build an SSHRunner from environment variables."""
+        host = os.environ.get("TUNE_SSH_HOST")
+        user = os.environ.get("TUNE_SSH_USER")
+        repo = os.environ.get("TUNE_SSH_REPO")
+        key  = os.environ.get("TUNE_SSH_KEY")
+
+        if not host or not user or not repo:
+            raise EnvironmentError(
+                "Missing required env vars: TUNE_SSH_HOST, TUNE_SSH_USER, TUNE_SSH_REPO"
+            )
+
+        return cls(host=host, user=user, repo_path=repo, key_path=key)
+
+    def run_trial(self, config_dict: dict) -> dict:
+        """
+        Send config_dict to the remote machine, run tune/worker.py, and return the
+        parsed metrics dict.
+
+        Steps:
+          1. Open SSH connection via paramiko
+          2. Pipe JSON config to stdin of `python tune/worker.py`
+          3. Read stdout, parse as JSON, return metrics dict
+          4. Raise RuntimeError on non-zero exit or JSON parse failure
+        """
+        import paramiko  # deferred so the module can be imported without paramiko installed
+
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        connect_kwargs: dict = dict(username=self.user, hostname=self.host)
+        if self.key_path:
+            connect_kwargs["key_filename"] = self.key_path
+
+        try:
+            client.connect(**connect_kwargs)
+
+            command = (
+                f"cd {self.repo_path} && "
+                f"python tune/worker.py"
+            )
+            stdin, stdout, stderr = client.exec_command(command)
+
+            # Send the config JSON on stdin and close the channel's write side
+            payload = json.dumps(config_dict)
+            stdin.write(payload)
+            stdin.channel.shutdown_write()
+
+            # Collect outputs
+            out_bytes = stdout.read()
+            err_bytes = stderr.read()
+            exit_status = stdout.channel.recv_exit_status()
+
+            # Forward worker stderr to our stderr for visibility
+            if err_bytes:
+                sys.stderr.buffer.write(err_bytes)
+                sys.stderr.flush()
+
+            if exit_status != 0:
+                raise RuntimeError(
+                    f"Worker exited with status {exit_status}. "
+                    f"Stderr: {err_bytes.decode(errors='replace')[:500]}"
+                )
+
+            try:
+                metrics = json.loads(out_bytes.decode())
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(
+                    f"Could not parse worker JSON output: {exc}. "
+                    f"Raw output: {out_bytes[:200]!r}"
+                ) from exc
+
+            return metrics
+
+        finally:
+            client.close()

--- a/tune/worker.py
+++ b/tune/worker.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# tune/worker.py
+"""
+Standalone worker script that runs one backtest trial and writes metrics to stdout.
+
+Usage:
+    python tune/worker.py < trial_config.json
+
+Input:  JSON object on stdin with keys matching BacktestConfig fields:
+          value_weight, momentum_weight, min_r2, lookback_days,
+          rebalance_frequency, trading_cost_pct
+
+Output: JSON metrics dict on stdout (all other output goes to stderr).
+        Exits with code 0 on success, 1 on failure.
+"""
+
+import json
+import sys
+import os
+
+
+def _redirect_stdout_to_stderr():
+    """Replace sys.stdout with a stderr-backed writer so print() goes to stderr."""
+    sys.stdout = sys.stderr
+
+
+def main():
+    # Redirect stdout to stderr before importing heavy modules so that any
+    # library startup chatter doesn't corrupt the JSON output channel.
+    real_stdout = sys.__stdout__
+    _redirect_stdout_to_stderr()
+
+    try:
+        raw = real_stdout.buffer.read() if hasattr(real_stdout, "buffer") else b""
+        # Re-read from the original stdin (before redirection)
+        raw = sys.__stdin__.read()
+        trial_config = json.loads(raw)
+    except Exception as exc:
+        print(f"[worker] ERROR reading stdin: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Build BacktestConfig from the trial params
+    try:
+        # Must import after stdout redirect so download progress goes to stderr
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from config import BacktestConfig, TradingCostConfig
+        from backtest.runner import run_backtest
+
+        value_weight    = float(trial_config.get("value_weight",    0.6))
+        momentum_weight = float(trial_config.get("momentum_weight", 0.4))
+
+        # Normalise so weights sum to at most 1.0
+        total = value_weight + momentum_weight
+        if total > 1.0:
+            value_weight    /= total
+            momentum_weight /= total
+
+        trading_cost_pct = float(trial_config.get("trading_cost_pct", 0.001))
+
+        config = BacktestConfig(
+            min_r2=float(trial_config.get("min_r2", 0.3)),
+            lookback_days=int(trial_config.get("lookback_days", 252)),
+            rebalance_frequency=str(trial_config.get("rebalance_frequency", "M")),
+            target_weights={
+                "Value":    value_weight,
+                "Momentum": momentum_weight,
+            },
+            trading_cost_config=TradingCostConfig(
+                pct_cost=trading_cost_pct,
+                min_cost=1.0,
+            ),
+        )
+
+        metrics = run_backtest(config)
+    except Exception as exc:
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        print(f"[worker] ERROR during backtest: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Strip private keys (objects that are not JSON-serialisable)
+    output = {k: v for k, v in metrics.items() if not k.startswith("_")}
+
+    # Write JSON to the real stdout
+    real_stdout.write(json.dumps(output))
+    real_stdout.flush()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tune_main.py
+++ b/tune_main.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# tune_main.py
+"""
+CLI entry point for Bayesian hyperparameter tuning.
+
+Usage:
+    python tune_main.py --n-trials 50 --host myserver.com --user ubuntu \
+                        --repo /home/ubuntu/portfolio [--key ~/.ssh/id_rsa]
+
+Credentials can also be supplied via env vars (TUNE_SSH_HOST, TUNE_SSH_USER,
+TUNE_SSH_REPO, TUNE_SSH_KEY); CLI flags take precedence.
+
+Outputs:
+  - Best params and score printed to stdout when done
+  - reports/tuning.db   — SQLite Optuna storage (all trials, resumable)
+  - reports/tuning_results.csv — flat CSV of all completed trials
+"""
+
+import argparse
+import os
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bayesian hyperparameter tuning for the portfolio backtest"
+    )
+    parser.add_argument("--n-trials",  type=int,  default=50,  help="Number of Optuna trials")
+    parser.add_argument("--host",      type=str,  default=None, help="SSH host (overrides TUNE_SSH_HOST)")
+    parser.add_argument("--user",      type=str,  default=None, help="SSH user (overrides TUNE_SSH_USER)")
+    parser.add_argument("--repo",      type=str,  default=None, help="Repo path on remote (overrides TUNE_SSH_REPO)")
+    parser.add_argument("--key",       type=str,  default=None, help="SSH key path (overrides TUNE_SSH_KEY)")
+    parser.add_argument("--study",     type=str,  default="portfolio-tuning", help="Optuna study name")
+    parser.add_argument("--storage",   type=str,  default="sqlite:///reports/tuning.db", help="Optuna storage URL")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Override env vars with CLI flags if provided
+    if args.host:
+        os.environ["TUNE_SSH_HOST"] = args.host
+    if args.user:
+        os.environ["TUNE_SSH_USER"] = args.user
+    if args.repo:
+        os.environ["TUNE_SSH_REPO"] = args.repo
+    if args.key:
+        os.environ["TUNE_SSH_KEY"] = args.key
+
+    from tune.ssh_runner import SSHRunner
+    from tune.orchestrator import run_study
+
+    try:
+        ssh_runner = SSHRunner.from_env()
+    except EnvironmentError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Starting Bayesian optimisation: {args.n_trials} trials")
+    print(f"  Remote:  {ssh_runner.user}@{ssh_runner.host}:{ssh_runner.repo_path}")
+    print(f"  Storage: {args.storage}")
+    print(f"  Study:   {args.study}\n")
+
+    study = run_study(
+        n_trials=args.n_trials,
+        ssh_runner=ssh_runner,
+        study_name=args.study,
+        storage=args.storage,
+    )
+
+    best = study.best_trial
+    print(f"\n{'='*52}")
+    print(f"  TUNING COMPLETE — {len(study.trials)} trials")
+    print(f"{'='*52}")
+    print(f"  Best score:  {best.value:.4f}")
+    print(f"  Best params:")
+    for k, v in best.params.items():
+        print(f"    {k:<26} {v}")
+    print(f"{'='*52}")
+
+    # Save all trials to CSV
+    import pandas as pd
+    import os
+
+    os.makedirs("reports", exist_ok=True)
+    rows = []
+    for t in study.trials:
+        row = {"trial": t.number, "score": t.value}
+        row.update(t.params)
+        row.update({f"metric_{k}": v for k, v in t.user_attrs.items()})
+        rows.append(row)
+
+    if rows:
+        df = pd.DataFrame(rows).sort_values("score", ascending=False)
+        csv_path = "reports/tuning_results.csv"
+        df.to_csv(csv_path, index=False)
+        print(f"\nAll trials saved to {csv_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Subtask 1 – Parameterise the backtest**: adds `BacktestConfig` dataclass to `config.py` and extracts the pipeline from `main.py` into `backtest/runner.py::run_backtest(config)`. `main.py` is now a thin wrapper around it.
- **Subtask 2 – Search space, objective, worker**: `tune/search_space.py` defines 6 hyperparameter ranges; `tune/objective.py` computes a composite score (0.5 × Sharpe + 0.3 × return − 0.2 × drawdown); `tune/worker.py` is a self-contained stdin→stdout script deployed on the remote machine.
- **Subtask 3 – SSH runner**: `tune/ssh_runner.py` wraps paramiko to ship a JSON config dict to the remote worker and return the parsed metrics dict. Credentials come from env vars (`TUNE_SSH_HOST`, `TUNE_SSH_USER`, `TUNE_SSH_REPO`, `TUNE_SSH_KEY`).
- **Subtask 4 – Orchestrator + CLI**: `tune/orchestrator.py` runs an Optuna TPE study (persisted to `reports/tuning.db`); `tune_main.py` is the CLI entry point.

## Test plan

- [ ] `python main.py` still runs identically (no regression)
- [ ] `echo '{"value_weight":0.6,"momentum_weight":0.4}' | python tune/worker.py` returns valid JSON metrics
- [ ] `python tune_main.py --n-trials 3 --host <host> --user <user> --repo <path>` completes 3 trials and writes `reports/tuning.db` + `reports/tuning_results.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)